### PR TITLE
add debug printout for orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 
 # Dotenv environment variables file
 .env
+
+experiment/

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -174,6 +174,14 @@ To generate many keys from a single originating key, use the following action:
 When no `password-env` is provided, empty password will be used to decode the originating private key (`./root-key`)
 and to encode new private keys (`./keys/key-0`, `./keys/key-1` ...).
 
+## Debug Printout
+
+You can enable debug printout of graphql requests by adding 
+
+`"printRequests":"true"` 
+
+in config.json **and** set `"logLevel":"debug"` or lower
+
 ## Build from sources
 
 - Make sure you have `Go v1.20+` installed.

--- a/orchestrator/src/data.go
+++ b/orchestrator/src/data.go
@@ -55,6 +55,7 @@ type Config struct {
 	StopDaemonDelaySec int
 	FundDaemonPorts    []string
 	UrlOverrides       []string
+	PrintRequests      bool
 }
 
 type OutputF = func(name string, value any, multiple bool, sensitive bool)

--- a/orchestrator/src/graphql.go
+++ b/orchestrator/src/graphql.go
@@ -104,7 +104,12 @@ var _ graphql.Doer = (*SequentialAuthenticator)(nil)
 
 func NewGqlClient(config Config, addr NodeAddress) (*NodeEntry, error) {
 	url := "http://" + string(addr) + "/graphql"
-	authenticator := NewAuthenticator(config.Sk, http.DefaultClient)
+	httpClient := http.DefaultClient
+	if config.PrintRequests {
+		rt := RoundTripper{logger: config.Log}
+		httpClient = &http.Client{Transport: rt}
+	}
+	authenticator := NewAuthenticator(config.Sk, httpClient)
 	authClient := graphql.NewClient(url, authenticator)
 	resp, err := auth(config.Ctx, authClient)
 	if err != nil {

--- a/orchestrator/src/http_roundtripper.go
+++ b/orchestrator/src/http_roundtripper.go
@@ -1,0 +1,36 @@
+package itn_orchestrator
+
+import (
+	"net/http"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+type RoundTripper struct {
+	logger logging.StandardLogger
+}
+
+func (t RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := readBody(req)
+	if err != nil {
+		return nil, err
+	}
+	reqBodyString := string(body)
+
+	var headers string
+	for name, values := range req.Header {
+		for _, value := range values {
+			headers += "\tHeaders: " + name + ": " + value + "\n"
+		}
+	}
+	t.logger.Debugf("RoundTripper: %s %s %s\nHeaders: %s", req.Method, req.URL, reqBodyString, headers)
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	t.logger.Debugf("RoundTripper: %s %s %s", resp.Status, resp.Request.Method, resp.Request.URL)
+
+	return resp, err
+}

--- a/orchestrator/src/itn_orchestrator/main.go
+++ b/orchestrator/src/itn_orchestrator/main.go
@@ -87,6 +87,7 @@ type AppConfig struct {
 	GenesisTimestamp itn_json_types.Time
 	ControlExec      string   `json:",omitempty"`
 	UrlOverrides     []string `json:",omitempty"`
+	PrintRequests    bool     `json:"printRequests,omitempty"`
 }
 
 func (config *AwsConfig) GetBucketName() string {
@@ -227,6 +228,7 @@ func main() {
 		ControlExec:      appConfig.ControlExec,
 		OnlineURL:        appConfig.OnlineURL,
 		UrlOverrides:     appConfig.UrlOverrides,
+		PrintRequests:    appConfig.PrintRequests,
 	}
 	if config.MinaExec == "" {
 		config.MinaExec = "mina"


### PR DESCRIPTION
Added debug printout for requests in order to aid us when debugging is needed for graphql. Printout can be defined in config file with loglevel below or equal debug