### PR TITLE
Remove uninformative debug log

### DIFF
--- a/orchestrator/src/orchestrator.go
+++ b/orchestrator/src/orchestrator.go
@@ -305,7 +305,6 @@ func RunActions(inDecoder *json.Decoder, config Config, outCache outCacheT, log 
 			})
 		} else {
 			log.Infof("Performing step %s (%d)", cmd.Action, step)
-			log.Debugf("Cache: %s, Params: %s", outCache, string(params))
 			err = action.Run(config, params, outputF(outCache, log, step))
 			if err != nil {
 				return &OrchestratorError{


### PR DESCRIPTION
Simple code modification.

Existing log is too verbose and spams the dashboard.
