### PR TITLE
Use X-Forwarded-For header for client IP

### DIFF
--- a/uptime-backend/src/uptime_backend/submit.go
+++ b/uptime-backend/src/uptime_backend/submit.go
@@ -189,6 +189,12 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if remoteAddr == "" {
 		// If there is no X-Forwarded-For header, use the remote address
 		remoteAddr = r.RemoteAddr
+	} else {
+		// X-Forwarded-For may be comma-separated; take the first entry (the original client IP)
+		if idx := strings.IndexByte(remoteAddr, ','); idx != -1 {
+			remoteAddr = remoteAddr[:idx]
+		}
+		remoteAddr = strings.TrimSpace(remoteAddr)
 	}
 
 	meta := req.MakeMetaToBeSaved(remoteAddr)


### PR DESCRIPTION
## Summary

- When `X-Forwarded-For` is present, extract the first (leftmost) entry from the potentially comma-separated list and trim whitespace
- Fall back to `r.RemoteAddr` when the header is absent (existing behaviour)

## Test plan

- [ ] Deploy behind a reverse proxy and verify the stored `remote_addr` reflects the original client IP from `X-Forwarded-For`
- [ ] Verify direct connections (no header) still record `r.RemoteAddr`
- [ ] Verify comma-separated values (e.g. `1.2.3.4, 10.0.0.1`) correctly yield `1.2.3.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)