### PR TITLE
orchestrator: non_default_token generator option (custom-owned-token zkApp load)

### DIFF
--- a/orchestrator/schema.graphql
+++ b/orchestrator/schema.graphql
@@ -191,6 +191,15 @@ input ZkappCommandsDetails {
   """Generate max cost zkApp command"""
   maxCost: Boolean!
 
+  """
+  When true, the scheduled (non-max-cost) zkApp load initializes a custom,
+  non-default (owned) token and transacts in it instead of the default MINA
+  token. Defaults to false. Has no effect when maxCost is set. Daemons that do
+  not define this field ignore it (ocaml-graphql-server drops unknown input
+  fields), so sending it (as false) to an older daemon is harmless.
+  """
+  nonDefaultToken: Boolean
+
   """The size of queue for recently used accounts"""
   accountQueueSize: Int!
 

--- a/orchestrator/src/generate.go
+++ b/orchestrator/src/generate.go
@@ -16,6 +16,7 @@ type GenParams struct {
 	StopCleanRatio, MinStopRatio, MaxStopRatio                           float64
 	RoundDurationMin, PauseMin, Rounds, StopsPerRound, Gap               int
 	SendFromNonBpsOnly, StopOnlyBps, UseRestartScript, MaxCost           bool
+	NonDefaultToken                                                      bool
 	ExperimentName, PasswordEnv, FundKeyPrefix                           string
 	Privkeys                                                             []string
 	PaymentReceiver                                                      itn_json_types.MinaPublicKey
@@ -52,6 +53,7 @@ func DefaultGenParams() GenParams {
 		StopOnlyBps:            false,
 		UseRestartScript:       false,
 		MaxCost:                false,
+		NonDefaultToken:        false,
 		ExperimentName:         "exp-0",
 		PasswordEnv:            "",
 		FundKeyPrefix:          "./fund_keys",
@@ -361,6 +363,7 @@ func (p *GenParams) Generate(round int) GeneratedRound {
 		MaxFee:           p.MaxZkappFee,
 		DeploymentFee:    p.DeploymentFee,
 		MaxCost:          maxCost,
+		NonDefaultToken:  p.NonDefaultToken,
 		NewAccountRatio:  p.NewAccountRatio,
 	}
 	if maxCost {

--- a/orchestrator/src/generate_validation.go
+++ b/orchestrator/src/generate_validation.go
@@ -51,6 +51,27 @@ func ValidationSteps(p *GenParams) []ValidationStep {
 			ExitCode: 2,
 		},
 		{
+			ErrorMsg: "non-default-token has no effect with max-cost (max-cost commands always use the default token)",
+			Check: func(p *GenParams) bool {
+				return p.NonDefaultToken && p.MaxCost
+			},
+			ExitCode: 2,
+		},
+		{
+			ErrorMsg: "non-default-token has no effect with max-cost-mixed (its stress rounds run max-cost commands)",
+			Check: func(p *GenParams) bool {
+				return p.NonDefaultToken && p.MaxCostMixedTpsRatio > 1e-3
+			},
+			ExitCode: 2,
+		},
+		{
+			ErrorMsg: "non-default-token requires a non-zero zkapp ratio (it only affects the zkApp load)",
+			Check: func(p *GenParams) bool {
+				return p.NonDefaultToken && p.ZkappRatio < 1e-3
+			},
+			ExitCode: 2,
+		},
+		{
 			ErrorMsg: "wrong large-pause-every: should be a positive number",
 			Check: func(p *GenParams) bool {
 				return p.LargePauseEveryNRounds <= 0

--- a/orchestrator/src/generator/main.go
+++ b/orchestrator/src/generator/main.go
@@ -30,6 +30,7 @@ func main() {
 	flag.BoolVar(&p.StopOnlyBps, "stop-only-bps", defaults.StopOnlyBps, "stop only block producers")
 	flag.BoolVar(&p.UseRestartScript, "use-restart-script", defaults.UseRestartScript, "use restart script instead of stop-daemon command")
 	flag.BoolVar(&p.MaxCost, "max-cost", defaults.MaxCost, "send max-cost zkapp commands")
+	flag.BoolVar(&p.NonDefaultToken, "non-default-token", defaults.NonDefaultToken, "drive the zkapp load in a custom, non-default (owned) token instead of MINA (no effect with -max-cost)")
 	flag.IntVar(&p.RoundDurationMin, "round-duration", defaults.RoundDurationMin, "duration of a round, minutes")
 	flag.IntVar(&p.PauseMin, "pause", defaults.PauseMin, "duration of a pause between rounds, minutes")
 	flag.IntVar(&p.Rounds, "rounds", defaults.Rounds, "number of rounds to run experiment")

--- a/orchestrator/src/service/inputs/generator.go
+++ b/orchestrator/src/service/inputs/generator.go
@@ -22,6 +22,7 @@ type GeneratorInputData struct {
 	StopOnlyBps            *bool                         `json:"stop_only_bps,omitempty"`
 	UseRestartScript       *bool                         `json:"use_restart_script,omitempty"`
 	MaxCost                *bool                         `json:"max_cost,omitempty"`
+	NonDefaultToken        *bool                         `json:"non_default_token,omitempty"`
 	RoundDurationMin       *int                          `json:"round_duration_min,omitempty"`
 	PauseMin               *int                          `json:"pause_min,omitempty"`
 	Rounds                 *int                          `json:"rounds,omitempty"`
@@ -76,6 +77,7 @@ func (inputData *GeneratorInputData) ApplyWithDefaults(p *lib.GenParams) {
 	lib.SetOrDefault(inputData.StopOnlyBps, &p.StopOnlyBps, defaults.StopOnlyBps)
 	lib.SetOrDefault(inputData.UseRestartScript, &p.UseRestartScript, defaults.UseRestartScript)
 	lib.SetOrDefault(inputData.MaxCost, &p.MaxCost, defaults.MaxCost)
+	lib.SetOrDefault(inputData.NonDefaultToken, &p.NonDefaultToken, defaults.NonDefaultToken)
 	lib.SetOrDefault(inputData.RoundDurationMin, &p.RoundDurationMin, defaults.RoundDurationMin)
 	lib.SetOrDefault(inputData.PauseMin, &p.PauseMin, defaults.PauseMin)
 	lib.SetOrDefault(inputData.Rounds, &p.Rounds, defaults.Rounds)

--- a/orchestrator/src/zkapp.go
+++ b/orchestrator/src/zkapp.go
@@ -21,6 +21,7 @@ type ZkappSubParams struct {
 	Gap              int     `json:"gap"`
 	NoPrecondition   bool    `json:"noPrecondition"`
 	MaxCost          bool    `json:"maxCost"`
+	NonDefaultToken  bool    `json:"nonDefaultToken"`
 	MinBalanceChange uint64  `json:"minBalanceChange"`
 	MaxBalanceChange uint64  `json:"maxBalanceChange"`
 	DeploymentFee    uint64  `json:"deploymentFee"`
@@ -99,6 +100,7 @@ func ZkappPaymentsInput(params ZkappSubParams, batchIx int, tps float64) ZkappCo
 		DeploymentFee:      params.DeploymentFee,
 		AccountQueueSize:   accountQueueSize,
 		MaxCost:            params.MaxCost,
+		NonDefaultToken:    params.NonDefaultToken,
 		MaxAccountUpdates:  2,
 	}
 }


### PR DESCRIPTION
# Orchestrator: `non_default_token` generator option

**Repo:** `o1-labs/mina-perf-testing`
**Branch:** `repro/orchestrator-non-default-token` — based on **`georgeee/orchestrator-retry-scheduling-fallbacks`**
**Patch:** `orchestrator-non-default-token.mbox` (1 commit, 6 files, +38)

## Summary

Adds a `non_default_token` knob to the load generator so an experiment can drive the scheduled zkApp load in a **custom, non-default (owned) token** instead of the default MINA token. It maps to the daemon-side `nonDefaultToken` field of the `scheduleZkappCommands` ITN mutation added by the compatible-based node branch (`branch1-compatible-custom-token.mbox`): the daemon stands up one owned token and transacts it between a fixed pool of holders.

This is the driver for reproducing archive bug **#18941** (`tokens_value_key`): minting an OWNED token on a pre-fork (compatible/Berkeley) network so it carries into the fork genesis ledger. (The other reproduction — the `element_ids` btree overflow on Mesa — needs **no** orchestrator change; it uses the existing `max_cost: true`.)

## What changed (threaded end to end)

| File | Change |
|---|---|
| `schema.graphql` | `nonDefaultToken: Boolean` on input `ZkappCommandsDetails` (genqlient regenerates `graphql_generated.go`). |
| `src/generate.go` | `GenParams.NonDefaultToken` (+ default `false`) → set on `ZkappSubParams` in `Generate`. |
| `src/zkapp.go` | `ZkappSubParams.NonDefaultToken` → `ZkappCommandsDetails.NonDefaultToken` in `ZkappPaymentsInput`. |
| `src/service/inputs/generator.go` | `non_default_token` field in the JSON generator config + `ApplyWithDefaults`. |
| `src/generator/main.go` | `-non-default-token` CLI flag. |
| `src/generate_validation.go` | Rejects `non_default_token` together with `max_cost` / `max_cost_mixed` (no effect on max-cost commands) and requires a non-zero `zkapp_ratio`. |

### Safety against non-supporting daemons

`nonDefaultToken` is a **nullable** input field. genqlient v0.5.0 serializes it unconditionally (as `false` when unset), but this is harmless: `ocaml-graphql-server` **drops input-object fields it does not declare**, so sending `nonDefaultToken: false` to a stock daemon (one without the branch-1 change) is a no-op. Only daemons built from `branch1-compatible-custom-token.mbox` act on it. No `omitempty`/pointer gymnastics are required, and existing experiments are unaffected.

## Usage

Generator config:

```json
{
  "base_tps": 0.02,
  "stress_tps": 0.03,
  "zkapp_ratio": 0.5,
  "rounds": 1,
  "round_duration_min": 30,
  "pause_min": 0,
  "max_cost": false,
  "non_default_token": true
}
```

or `generator ... -non-default-token`.

Validation refuses:
* `non_default_token` + `max_cost` — max-cost commands always use the default token.
* `non_default_token` + `max_cost_mixed > 0` — its stress rounds run max-cost commands.
* `non_default_token` + `zkapp_ratio == 0` — nothing to act on (it only affects the zkApp load).

## Build / verify

```bash
cd orchestrator
make generator orchestrator orchestrator_service   # runs genqlient, then go build
# (verified here: `go run github.com/Khan/genqlient ../genqlient.yaml` + `go build ./...` succeed;
#  the generated ZkappCommandsDetails carries NonDefaultToken.)
```
