### PR TITLE
orchestrator: fix load-keys password + bump mina-mesa-mut

### DIFF
--- a/orchestrator/Dockerfile-service
+++ b/orchestrator/Dockerfile-service
@@ -42,8 +42,8 @@ RUN echo "downloading mina" \
   && echo "deb [trusted=yes] http://packages.o1test.net jammy umt" > /etc/apt/sources.list.d/mina.list \
   && apt-get update --quiet --yes \
   && apt-get install --quiet --yes --allow-downgrades \
-    mina-mesa-mut=4.0.0-rc1-mesa-mut-d7513d4 \
-    mina-mesa-mut-config=4.0.0-rc1-mesa-mut-d7513d4 \
+    mina-mesa-mut=4.0.0-rc1-83b4654 \
+    mina-mesa-mut-config=4.0.0-rc1-83b4654 \
   && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "/bin/sh", "-c", "/orchestrator_service -conn \"$PSQL_CONNECTION_STRING\" -config \"$CONFIG\" -address \":9090\"" ]

--- a/orchestrator/src/generate.go
+++ b/orchestrator/src/generate.go
@@ -427,14 +427,14 @@ func (p *GenParams) Generate(round int) GeneratedRound {
 		participantsRef = -1
 	}
 	if onlyPayments {
-		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: paymentsKeysDir}))
+		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: paymentsKeysDir, PasswordEnv: p.PasswordEnv}))
 		cmds = append(cmds, payments(-1, participantsRef-1, participantsName, paymentParams))
 	} else if onlyZkapps {
-		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: zkappsKeysDir}))
+		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: zkappsKeysDir, PasswordEnv: p.PasswordEnv}))
 		cmds = append(cmds, zkapps(-1, participantsRef-1, participantsName, zkappParams))
 	} else {
-		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: zkappsKeysDir}))
-		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: paymentsKeysDir}))
+		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: zkappsKeysDir, PasswordEnv: p.PasswordEnv}))
+		cmds = append(cmds, loadKeys(KeyloaderParams{Dir: paymentsKeysDir, PasswordEnv: p.PasswordEnv}))
 		cmds = append(cmds, zkapps(-2, participantsRef-2, participantsName, zkappParams))
 		cmds = append(cmds, payments(-2, participantsRef-3, participantsName, paymentParams))
 		cmds = append(cmds, join(-1, "participant", -2, "participant"))


### PR DESCRIPTION
## Summary

Two fixes surfaced while running the orchestrator-as-service with a password-protected fee-payer key:

1. **`load-keys` password mismatch** — `mina itn-create-accounts` (fund step) encrypts the generated batch account keyfiles with `MINA_PRIVKEY_PASS`. Once a non-empty `password_env` is configured, the fund step seals those keys with the real password, but the generated `load-keys` steps were constructed without `PasswordEnv`, so they tried to unseal with an empty password and failed with `failed to unseal key`. Now `p.PasswordEnv` is threaded into all `loadKeys()` calls so sealing and unsealing use the same env var.

2. **Dockerfile-service** — bump `mina-mesa-mut` / `mina-mesa-mut-config` to `4.0.0-rc1-83b4654`.

## Testing

- `go build ./...` passes.
- Reproduced the original `failed to unseal key` error at the `load-keys` step in a live `orchestrator-as-service` run; this change makes the load-keys password match the fund password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)